### PR TITLE
feat(api): add date range and sort order to search endpoint

### DIFF
--- a/api/youtube.py
+++ b/api/youtube.py
@@ -2,11 +2,29 @@
 
 """YouTube Data API v3 integration for video search."""
 
+from datetime import datetime
 import os
 import logging
 from typing import List, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_iso8601(timestamp: str) -> bool:
+    """Validate ISO 8601 / RFC 3339 timestamp format."""
+    formats = [
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+        "%Y-%m-%dT%H:%M:%S%z",
+        "%Y-%m-%dT%H:%M:%S.%f%z",
+    ]
+    for fmt in formats:
+        try:
+            datetime.strptime(timestamp, fmt)
+            return True
+        except ValueError:
+            continue
+    return False
 
 
 def search_videos(
@@ -49,9 +67,14 @@ def search_videos(
             "Install with: uv pip install google-api-python-client"
         ) from e
 
-    valid_orders = {"relevance", "date", "rating", "viewCount"}
+    valid_orders = ["date", "rating", "relevance", "viewCount"]  # sorted for deterministic error message
     if order not in valid_orders:
         raise ValueError(f"order must be one of: {', '.join(valid_orders)}")
+
+    if published_after and not _validate_iso8601(published_after):
+        raise ValueError(
+            "published_after must be ISO 8601 format (e.g., 2026-03-01T00:00:00Z)"
+        )
 
     logger.info(f"Searching YouTube: query='{query}', max_results={max_results}, order={order}, published_after={published_after}")
 

--- a/main.py
+++ b/main.py
@@ -113,6 +113,8 @@ def search(
 
         return {"query": q, "count": len(results), "results": results}
 
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except ImportError as e:
         raise HTTPException(status_code=500, detail=str(e))
     except Exception as e:
@@ -172,7 +174,7 @@ def root():
         "version": "1.0.0",
         "endpoints": {
             "health": "GET /health",
-            "search": "GET /search?q={query}&max_results={n}",
+            "search": "GET /search?q={query}&max_results={n}&order={relevance|date|rating|viewCount}&published_after={ISO8601}",
             "transcript": "POST /transcript",
             "job": "GET /job/{job_id}",
         },


### PR DESCRIPTION
## Problem

YouTube search endpoint hardcodes `order=relevance` and has no date filtering. This prevents time-bounded video discovery workflows.

## Changes

- Add `order` query parameter (relevance, date, rating, viewCount)
- Add `published_after` query parameter (ISO 8601 timestamp)
- Update `search_videos()` to accept and pass these parameters to YouTube API
- Validate order against allowed values
- Backward compatible: defaults maintain previous behavior

## Usage Examples

```bash
# Sort by date
GET /search?q=OpenClaw&order=date

# Filter videos from March 2026 onwards
GET /search?q=OpenClaw&published_after=2026-03-01T00:00:00Z

# Combine both
GET /search?q=OpenClaw&order=date&published_after=2026-03-01T00:00:00Z
```

## Testing

- [ ] Manual test with different order values
- [ ] Manual test with date filter
- [ ] Verify backward compatibility (default params)

Closes #1